### PR TITLE
Build-Pipeline trigger bei Pull-Request hinzugefügt

### DIFF
--- a/.github/workflows/PR-Build.yml
+++ b/.github/workflows/PR-Build.yml
@@ -4,7 +4,7 @@ on:
       branches:
         - master
 jobs:
-  build-and-deploy:
+  build-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/PR-Build.yml
+++ b/.github/workflows/PR-Build.yml
@@ -1,0 +1,16 @@
+name: PR-Build
+on:
+  pull_request:
+      branches:
+        - master
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        
+      - name: Install and Build
+        run: |
+          npm install
+          npm run build


### PR DESCRIPTION
Problem
- bei Pull-Requests auf den Master wird der Code nicht überprüft. Das führt dazu, dass Code mit Warnings in den Master gemerged werden kann.

Lösung
- das Problem wird vermieden durch einen Build nach stellen des Pull-Requests.

closes #33 