### PR TITLE
Feature/höhere punktezahl für größere münzen

### DIFF
--- a/src/State/slices/gameFieldSlice.ts
+++ b/src/State/slices/gameFieldSlice.ts
@@ -9,6 +9,7 @@ import Moveable from '../../Types/Moveable';
 import { setRandomDirectionAndCount } from '../../UtilityFunctions/GetRandomNumber';
 import { moveGhost } from '../../UtilityFunctions/move/MoveGhost';
 import React from 'react';
+import CoinValue from '../../Types/CoinValue';
 
 const initialStateHackman:Character = new Character("Hackman",12,10);
 const ghost1 = new GhostCharacter("Ghost1",7,9);
@@ -29,7 +30,7 @@ const gameFieldSlice = createSlice({
     reducers: {
       gameTick: (state) =>{
         let gameFieldForAll:React.FC<any>[][] = state.gameField.slice();
-        let increaseCoins = false;
+        let increaseCoins: CoinValue = 0;
           if(state.hackman.moveable === Moveable.Yes){
             let {gameField,increaseTheCoins} = moveHackman(state.gameField,state.hackman);
             gameFieldForAll = gameField;
@@ -47,9 +48,9 @@ const gameFieldSlice = createSlice({
                 gameFieldForAll = moveGhost(gameFieldForAll,ghost);
               }
           });
-          if(increaseCoins){
-            state.eatenCoins++;
-          }
+          if(increaseCoins === CoinValue.One) state.eatenCoins++;
+          else if (increaseCoins === CoinValue.Five) state.eatenCoins += 5;
+
           state.hackman.moveable = canMove(gameFieldForAll,state.hackman.getPosition,state.hackman.direction);
           state.gameField = gameFieldForAll;
       },

--- a/src/Types/CoinValue.tsx
+++ b/src/Types/CoinValue.tsx
@@ -1,0 +1,7 @@
+enum CoinValue {
+    Zero,
+    One,
+    Five,
+}
+
+export default CoinValue;

--- a/src/UtilityFunctions/move/CanMove.ts
+++ b/src/UtilityFunctions/move/CanMove.ts
@@ -9,6 +9,7 @@ import Moveable from "../../Types/Moveable";
 import Coordinate from "../../Types/Coordinate";
 import Direction from "../../Types/Direction";
 import Hackman from "../../Components/GameFieldComponent/HackmanComponent/Hackman";
+import CoinValue from "../../Types/CoinValue";
 
 function canMoveUp(spielFeld:React.FC<{}>[][],position:Coordinate):Moveable{
   let positionValue = position.y - 1;
@@ -108,23 +109,32 @@ function getPossibleDirections(spielFeld:React.FC<{}>[][],position:Coordinate):{
 
   return canMoveDirections;
 }
-  
-function checkCoins(gameField:React.FC<{}>[][],direction:Direction,position:Coordinate): boolean{
+
+function isEdible(gameField:React.FC<{}>[][],direction:Direction,position:Coordinate): CoinValue{
   switch(direction){
     case Direction.Up:{
-      return (gameField[position.y - 1][position.x] === Coin || gameField[position.y - 1][position.x] === Snack)
+      if (gameField[position.y - 1][position.x] === Coin) return CoinValue.One;
+      else if (gameField[position.y - 1][position.x] === Snack) return CoinValue.Five;
+      else return CoinValue.Zero;
     }
     case Direction.Left: {
-      return(gameField[position.y][position.x - 1] === Coin || gameField[position.y][position.x - 1] === Snack)
+      if (gameField[position.y][position.x - 1] === Coin) return CoinValue.One;
+      else if (gameField[position.y][position.x - 1] === Snack) return CoinValue.Five;
+      else return CoinValue.Zero;
     }
     case Direction.Down:{
-      return(gameField[position.y + 1][position.x] === Coin || gameField[position.y + 1][position.x] === Snack)
+      if (gameField[position.y + 1][position.x] === Coin) return CoinValue.One;
+      else if (gameField[position.y + 1][position.x] === Snack) return CoinValue.Five;
+      else return CoinValue.Zero;
     }
     case Direction.Right:{
-      return(gameField[position.y][position.x + 1] === Coin || gameField[position.y][position.x + 1] === Snack)
+      if (gameField[position.y][position.x + 1] === Coin) return CoinValue.One;
+      else if (gameField[position.y][position.x + 1] === Snack) return CoinValue.Five;
+      else return CoinValue.Zero;
     }
     default:
-      return false;
+      return CoinValue.Zero;
   }
 }
-  export {canMove,canMoveRight,canMoveLeft,canMoveDown,canMoveUp,getPossibleDirections,checkCoins};
+
+export {canMove,canMoveRight,canMoveLeft,canMoveDown,canMoveUp,getPossibleDirections,isEdible};

--- a/src/UtilityFunctions/move/CanMove.ts
+++ b/src/UtilityFunctions/move/CanMove.ts
@@ -110,6 +110,7 @@ function getPossibleDirections(spielFeld:React.FC<{}>[][],position:Coordinate):{
   return canMoveDirections;
 }
 
+// returns the written statistical Value of the next Field by Direction
 function isEdible(gameField:React.FC<{}>[][],direction:Direction,position:Coordinate): CoinValue{
   switch(direction){
     case Direction.Up:{

--- a/src/UtilityFunctions/move/MoveHackman.ts
+++ b/src/UtilityFunctions/move/MoveHackman.ts
@@ -2,7 +2,7 @@ import Character from "../../Types/Character/Character";
 import Empty from "../../Components/GameFieldComponent/FieldComponents/Path/Empty";
 import Moveable from "../../Types/Moveable";
 import Direction from "../../Types/Direction";
-import { checkCoins } from "./CanMove";
+import { isEdible } from "./CanMove";
 import { WritableDraft } from "@reduxjs/toolkit/node_modules/immer/dist/internal";
 import React from "react";
 import Hackman from "../../Components/GameFieldComponent/HackmanComponent/Hackman";
@@ -69,28 +69,28 @@ function moveHackman(gameField: React.FC<{}>[][], hackman: WritableDraft<Charact
   if (hackman.moveable === Moveable.Yes) {
     switch (hackman.direction) {
       case Direction.Up: {
-        if (checkCoins(gameField, Direction.Up, hackman.getPosition)) {
+        if (isEdible(gameField, Direction.Up, hackman.getPosition)) {
           increaseTheCoins = true;
         }
         gameField = hackmanMovesUp(gameField, hackman);
         break;
       }
       case Direction.Right: {
-        if (checkCoins(gameField, Direction.Right, hackman.getPosition)) {
+        if (isEdible(gameField, Direction.Right, hackman.getPosition)) {
           increaseTheCoins = true;
         }
         gameField = hackmanMovesRight(gameField, hackman);
         break;
       }
       case Direction.Down: {
-        if (checkCoins(gameField, Direction.Down, hackman.getPosition)) {
+        if (isEdible(gameField, Direction.Down, hackman.getPosition)) {
           increaseTheCoins = true;
         }
         gameField = hackmanMovesDown(gameField, hackman);
         break;
       }
       case Direction.Left: {
-        if (checkCoins(gameField, Direction.Left, hackman.getPosition)) {
+        if (isEdible(gameField, Direction.Left, hackman.getPosition)) {
           increaseTheCoins = true;
         }
         gameField = hackmanMovesLeft(gameField, hackman);

--- a/src/UtilityFunctions/move/MoveHackman.ts
+++ b/src/UtilityFunctions/move/MoveHackman.ts
@@ -6,6 +6,7 @@ import { isEdible } from "./CanMove";
 import { WritableDraft } from "@reduxjs/toolkit/node_modules/immer/dist/internal";
 import React from "react";
 import Hackman from "../../Components/GameFieldComponent/HackmanComponent/Hackman";
+import CoinValue from "../../Types/CoinValue";
 
 
 function hackmanMovesUp(spielFeldCopy: React.FC<{}>[][], hackman: WritableDraft<Character>): React.FC<{}>[][] {
@@ -64,35 +65,31 @@ function hackmanMovesDownTroughPortal(spielFeldCopy: React.FC<{}>[][], hackman: 
   return spielFeldCopy;
 }
 
-function moveHackman(gameField: React.FC<{}>[][], hackman: WritableDraft<Character>): { gameField: React.FC<{}>[][], increaseTheCoins: boolean } {
-  let increaseTheCoins: boolean = false;
+function moveHackman(gameField: React.FC<{}>[][], hackman: WritableDraft<Character>): { gameField: React.FC<{}>[][], increaseTheCoins: CoinValue } {
+  let increaseTheCoins: CoinValue = 0;
   if (hackman.moveable === Moveable.Yes) {
     switch (hackman.direction) {
       case Direction.Up: {
-        if (isEdible(gameField, Direction.Up, hackman.getPosition)) {
-          increaseTheCoins = true;
-        }
+        increaseTheCoins = isEdible(gameField, Direction.Up, hackman.getPosition);
+
         gameField = hackmanMovesUp(gameField, hackman);
         break;
       }
       case Direction.Right: {
-        if (isEdible(gameField, Direction.Right, hackman.getPosition)) {
-          increaseTheCoins = true;
-        }
+        increaseTheCoins = isEdible(gameField, Direction.Right, hackman.getPosition);
+
         gameField = hackmanMovesRight(gameField, hackman);
         break;
       }
       case Direction.Down: {
-        if (isEdible(gameField, Direction.Down, hackman.getPosition)) {
-          increaseTheCoins = true;
-        }
+        increaseTheCoins = isEdible(gameField, Direction.Down, hackman.getPosition);
+        
         gameField = hackmanMovesDown(gameField, hackman);
         break;
       }
       case Direction.Left: {
-        if (isEdible(gameField, Direction.Left, hackman.getPosition)) {
-          increaseTheCoins = true;
-        }
+        increaseTheCoins = isEdible(gameField, Direction.Left, hackman.getPosition); 
+
         gameField = hackmanMovesLeft(gameField, hackman);
         break;
       }


### PR DESCRIPTION
Ausgangslage:
 - Aktuell wird der Punktestand immer um "1" erhöht, sobald der Hackman eine Münze isst

Lösung:
 - Kollidiert der Hackman mit einer großen Münze auf dem Spielfeld, wird der Punktestand um 5 Punkte erhöht

Testbarkeit:
 - Starten sie das Spiel und steuern sie den Hackman mit den Pfeiltasten oder "WASD" zu einem großen Coin und lassen sie den 
    Hackman den Coin essen
 - der Punktestand wird dann um 5 erhöht

Closes #40 