### PR TITLE
Einführung Staging-System

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,23 +1,21 @@
-name: Build and Deploy
-on:
-  push:
-      branches:
-        - master
+name: Build and Deploy (manually)
+on: workflow_dispatch
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
+      - name: Checkout
         uses: actions/checkout@v2.3.1
         
-      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+      - name: Install and Build
         run: |
           npm install
           npm run build
 
-      - name: Deploy 🚀
+      - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:
-          branch: gh-pages # The branch the action should deploy to.
+          branch: gh-pages
           folder: ./build
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,29 @@
+name: staging hackman
+
+on:
+  push:
+    branches:
+      - staging
+
+
+jobs:
+
+  build-and-deploy-to-staging:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+        with:
+          ref: staging
+        
+      - name: Install and Build 
+        run: |
+          npm install
+          npm run build
+          
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: gh-pages
+          folder: ./build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           branch: gh-pages
           folder: ./build
+          target-folder: ./staging


### PR DESCRIPTION
Ausgangslage:
 - es existiert kein Staging-System, das führt dazu das in den Master gemergte Branches ohne PO abnahme Live gehen

Lösung: 
 - ein neuer Workflow der nach push in den Staging Branch ausgeführt wird und via GitHub Pages in die Staging Umgebung deployed

Testbarkeit:
- über das Github-Repo auf die Github-Pages Seite manövrieren und an die Url "staging" hinten anfügen

closes #45 