### PR TITLE
Geister können gegessen werden

### DIFF
--- a/src/State/slices/gameFieldSlice.ts
+++ b/src/State/slices/gameFieldSlice.ts
@@ -10,6 +10,7 @@ import { setRandomDirectionAndCount } from '../../UtilityFunctions/GetRandomNumb
 import { moveGhost } from '../../UtilityFunctions/move/MoveGhost';
 import React from 'react';
 import CoinValue from '../../Types/CoinValue';
+import Empty from '../../Components/GameFieldComponent/FieldComponents/Path/Empty';
 //import Coordinate from '../../Types/Coordinate';
 
 const initialStateHackman:Character = new Character("Hackman",12,10);
@@ -44,18 +45,89 @@ const gameFieldSlice = createSlice({
               state.eatenCoins += 10;
               switch(state.hackman.moveable){
                 case Moveable.GhostEdible1:
-                  state.ghosts[0].resetToStartPosition()
-                  // setGhostToInitialPosition()
-                  break;
-                case Moveable.GhostEdible2:
-                  state.ghosts[1].resetToStartPosition();
-                  break;
+                  if(gameFieldForAll[7][9] === Empty){
+                    state.ghosts[0].resetToStartPosition(0, 0)
+                    break
+                  }
+                  else if(gameFieldForAll[8][9] === Empty){
+                    state.ghosts[0].resetToStartPosition(1, 0)
+                    break
+                  }
+                  else if(gameFieldForAll[7][10] === Empty){
+                    state.ghosts[0].resetToStartPosition(0, 1)
+                    break
+                  }
+                  else if(gameFieldForAll[8][10] === Empty){
+                    state.ghosts[0].resetToStartPosition(1, 1)
+                    break
+                  }
+                  else{
+                    console.log("Das geht doch nicht " + state.ghosts[0].name)
+                    break
+                  }
+                  case Moveable.GhostEdible2:
+                    if(gameFieldForAll[7][11] === Empty){
+                      state.ghosts[1].resetToStartPosition(0, 0)
+                      break
+                    }
+                    else if(gameFieldForAll[7][10] === Empty){
+                      state.ghosts[1].resetToStartPosition(0, -1)
+                      break
+                    }
+                    else if(gameFieldForAll[8][11] === Empty){
+                      state.ghosts[1].resetToStartPosition(1, 0)
+                      break
+                    }
+                    else if(gameFieldForAll[8][10] === Empty){
+                      state.ghosts[1].resetToStartPosition(1, -1)
+                      break
+                    }
+                    else{
+                      console.log("Das geht doch nicht " + state.ghosts[1].name)
+                      break
+                    }
                 case Moveable.GhostEdible3:
-                  state.ghosts[2].resetToStartPosition();
-                  break;
+                  if(gameFieldForAll[9][9] === Empty){
+                    state.ghosts[2].resetToStartPosition(0, 0)
+                    break
+                  }
+                  else if(gameFieldForAll[8][9] === Empty){
+                    state.ghosts[2].resetToStartPosition(-1, 0)
+                    break
+                  }
+                  else if(gameFieldForAll[9][10] === Empty){
+                    state.ghosts[2].resetToStartPosition(0, 1)
+                    break
+                  }
+                  else if(gameFieldForAll[8][10] === Empty){
+                    state.ghosts[2].resetToStartPosition(-1, 1)
+                    break
+                  }
+                  else{
+                    console.log("Das geht doch nicht " + state.ghosts[2].name)
+                    break
+                  }
                 case Moveable.GhostEdible4:
-                  state.ghosts[3].resetToStartPosition();
-                  break;
+                  if(gameFieldForAll[9][11] === Empty){
+                    state.ghosts[3].resetToStartPosition(0, 0)
+                    break
+                  }
+                  else if(gameFieldForAll[8][11] === Empty){
+                    state.ghosts[3].resetToStartPosition(-1, 0)
+                    break
+                  }
+                  else if(gameFieldForAll[9][10] === Empty){
+                    state.ghosts[3].resetToStartPosition(0, -1)
+                    break
+                  }
+                  else if(gameFieldForAll[8][10] === Empty){
+                    state.ghosts[3].resetToStartPosition(-1, -1)
+                    break
+                  }
+                  else{
+                    console.log("Das geht doch nicht " + state.ghosts[3].name)
+                    break
+                  }
               }
             }   
           }

--- a/src/State/slices/gameFieldSlice.ts
+++ b/src/State/slices/gameFieldSlice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { canMove, getPossibleDirections} from '../../UtilityFunctions/move/CanMove';
 import SpielfeldLayout from '../../SpielfeldLayout'
 import Character from '../../Types/Character/Character';
-import { moveHackman } from '../../UtilityFunctions/move/MoveHackman';
+import { hackmanMovesDown, moveHackman } from '../../UtilityFunctions/move/MoveHackman';
 import Direction from '../../Types/Direction';
 import GhostCharacter from '../../Types/Character/GhostCharacter';
 import Moveable from '../../Types/Moveable';
@@ -36,28 +36,28 @@ const gameFieldSlice = createSlice({
       gameTick: (state) =>{
         let gameFieldForAll:React.FC<any>[][] = state.gameField.slice();
         let increaseCoins: CoinValue = 0;
-          if(state.hackman.moveable === Moveable.Yes || state.hackman.moveable === Moveable.Portal){
+          if(state.hackman.moveable !== Moveable.No){
             let {gameField,increaseTheCoins} = moveHackman(state.gameField,state.hackman);
             gameFieldForAll = gameField;
             increaseCoins = increaseTheCoins; 
-            // if(increaseCoins === CoinValue.Ten){
-            //   state.eatenCoins += 10;
-            //   switch(state.hackman.moveable){
-            //     case Moveable.GhostEdible1:
-            //       state.ghosts[0].resetToStartPosition()
-            //       // setGhostToInitialPosition()
-            //       break;
-            //     case Moveable.GhostEdible2:
-            //       state.ghosts[1].resetToStartPosition();
-            //       break;
-            //     case Moveable.GhostEdible3:
-            //       state.ghosts[2].resetToStartPosition();
-            //       break;
-            //     case Moveable.GhostEdible4:
-            //       state.ghosts[3].resetToStartPosition();
-            //       break;
-            //   }
-            // }   
+            if(increaseCoins === CoinValue.Ten){
+              state.eatenCoins += 10;
+              switch(state.hackman.moveable){
+                case Moveable.GhostEdible1:
+                  state.ghosts[0].resetToStartPosition()
+                  // setGhostToInitialPosition()
+                  break;
+                case Moveable.GhostEdible2:
+                  state.ghosts[1].resetToStartPosition();
+                  break;
+                case Moveable.GhostEdible3:
+                  state.ghosts[2].resetToStartPosition();
+                  break;
+                case Moveable.GhostEdible4:
+                  state.ghosts[3].resetToStartPosition();
+                  break;
+              }
+            }   
           }
           
           state.ghosts.forEach( ghost => {

--- a/src/State/slices/gameFieldSlice.ts
+++ b/src/State/slices/gameFieldSlice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { canMove, getPossibleDirections} from '../../UtilityFunctions/move/CanMove';
 import SpielfeldLayout from '../../SpielfeldLayout'
 import Character from '../../Types/Character/Character';
-import { hackmanMovesDown, moveHackman } from '../../UtilityFunctions/move/MoveHackman';
+import { moveHackman } from '../../UtilityFunctions/move/MoveHackman';
 import Direction from '../../Types/Direction';
 import GhostCharacter from '../../Types/Character/GhostCharacter';
 import Moveable from '../../Types/Moveable';

--- a/src/Types/Character/Character.ts
+++ b/src/Types/Character/Character.ts
@@ -2,50 +2,51 @@ import Moveable from "../Moveable";
 import Coordinate from "../Coordinate";
 import Direction from "../Direction";
 
-class Character{
-    private _name: string;
-    public get name() : string{
-      return this._name;
-    }
-    private _initialPosition:Coordinate;
+class Character {
+  private _name: string;
+  public get name(): string {
+    return this._name;
+  }
+  private _initialPosition: Coordinate;
 
-    private _position :Coordinate;
-    public set setPositionX(value:number){
-      this._position.x = value;
+  private _position: Coordinate;
+  public set setPositionX(value: number) {
+    this._position.x = value;
+  }
+  public set positionY(value: number) {
+    this._position.y = value;
+  }
+  public get getPosition(): Coordinate {
+    return this._position;
+  }
+  private _direction: Direction;
+  public set setBewegungsRichtung(value: Direction) {
+    this._direction = value;
+  }
+  public get direction(): Direction {
+    return this._direction;
+  }
+
+  private _moveable: Moveable;
+  public set moveable(value: Moveable) {
+    if (value !== this._moveable) {
+      this._moveable = value;
     }
-    public set positionY(value:number){
-      this._position.y = value;
-    }
-    public get getPosition() : Coordinate{
-      return this._position;
-    }
-    private _direction: Direction;
-    public set setBewegungsRichtung(value:Direction){
-      this._direction = value;
-    }
-    public get direction() : Direction{
-      return this._direction;
-    }
-    
-    private _moveable: Moveable;
-    public set moveable(value:Moveable){
-      if(value !== this._moveable){
-        this._moveable = value;
-      }
-    }
-    public get moveable() : Moveable{
-      return this._moveable;
-    }
-  
-    public resetToStartPosition(){
-      this._position = this._initialPosition;
-    }
-    constructor(name:string,positionY:number,positionX:number){
-      this._name = name;
-      this._position=  new Coordinate(positionY,positionX);
-      this._initialPosition = new Coordinate(positionY,positionX);
-      this._direction = Direction.Nothing;
-      this._moveable = Moveable.No;
-    }
-  } 
+  }
+  public get moveable(): Moveable {
+    return this._moveable;
+  }
+
+  public resetToStartPosition(y: number, x: number) {
+    this._position.x = this._initialPosition.x + x;
+    this._position.y = this._initialPosition.y + y;
+  }
+  constructor(name: string, positionY: number, positionX: number) {
+    this._name = name;
+    this._position = new Coordinate(positionY, positionX);
+    this._initialPosition = new Coordinate(positionY, positionX);
+    this._direction = Direction.Nothing;
+    this._moveable = Moveable.No;
+  }
+} 
   export default Character;

--- a/src/Types/Character/GhostCharacter.ts
+++ b/src/Types/Character/GhostCharacter.ts
@@ -2,62 +2,64 @@ import Empty from "../../Components/GameFieldComponent/FieldComponents/Path/Empt
 import CustomTimerForGhostEdible from "../../UtilityFunctions/Interval_And_Timer/CustomTimerForGhostEdible";
 import Character from "./Character";
 
-class GhostCharacter extends Character{
-    private _shallTick:boolean;
-    public set shallTick(value:boolean){
-      this._shallTick = value;
-    };
-    public get shallTick() : boolean{
-      return this._shallTick;
-    };
-    private _isEdibleTimeout: CustomTimerForGhostEdible;
-    private _isEdible:boolean;
-    public set isEdible(value:boolean){
-      this._isEdible = value;
-      if(this._isEdible){
-        this._isEdibleTimeout.start();
-      }
-      else{
-        this._isEdibleTimeout.stop();
-      }
-    };
-    public get isEdible() : boolean{
-      return this._isEdible;
-    };
-    private _declaredCount: number;
-    public set declaredCount(value:number){
-      this._declaredCount = value;
-      this.resetCount();
-    };
-    private _count: number;
-    public incrementCount(){
-      this._count++
-    };
-    private resetCount(){
-      this._count = 0;
-    };
-    public needsNewCountDeclaration():boolean{
-      return this._declaredCount === this._count;
-    };
-    private _cachedField:React.FC<{}>;
-    public get cachedField(){
-      return this._cachedField;
-    };
-    public set cachedField(value:React.FC<{}>){
-    this._cachedField = value;
-    };
-    public override resetToStartPosition(){
-      super.resetToStartPosition();
-      this.isEdible = false;
-    }
-    constructor(name:string,positionY:number,positionX:number){
-      super(name,positionY,positionX);
-      this._isEdibleTimeout = new CustomTimerForGhostEdible(()=>this.isEdible = false,15000);
-      this._shallTick = false;
-      this._declaredCount = 0;
-      this._count = 0;
-      this._cachedField = Empty;
-      this._isEdible = false;
+class GhostCharacter extends Character {
+  private _shallTick: boolean;
+  public set shallTick(value: boolean) {
+    this._shallTick = value;
+  }
+  public get shallTick(): boolean {
+    return this._shallTick;
+  }
+  private _isEdibleTimeout: CustomTimerForGhostEdible;
+  private _isEdible: boolean;
+  public set isEdible(value: boolean) {
+    this._isEdible = value;
+    if (this._isEdible) {
+      this._isEdibleTimeout.start();
+    } else {
+      this._isEdibleTimeout.stop();
     }
   }
+  public get isEdible(): boolean {
+    return this._isEdible;
+  }
+  private _declaredCount: number;
+  public set declaredCount(value: number) {
+    this._declaredCount = value;
+    this.resetCount();
+  }
+  private _count: number;
+  public incrementCount() {
+    this._count++;
+  }
+  private resetCount() {
+    this._count = 0;
+  }
+  public needsNewCountDeclaration(): boolean {
+    return this._declaredCount === this._count;
+  }
+  private _cachedField: React.FC<{}>;
+  public get cachedField() {
+    return this._cachedField;
+  }
+  public set cachedField(value: React.FC<{}>) {
+    this._cachedField = value;
+  }
+  public override resetToStartPosition(y: number, x: number) {
+    super.resetToStartPosition(y, x);
+    this.isEdible = false;
+  }
+  constructor(name: string, positionY: number, positionX: number) {
+    super(name, positionY, positionX);
+    this._isEdibleTimeout = new CustomTimerForGhostEdible(
+      () => (this.isEdible = false),
+      15000
+    );
+    this._shallTick = false;
+    this._declaredCount = 0;
+    this._count = 0;
+    this._cachedField = Empty;
+    this._isEdible = false;
+  }
+}
   export default GhostCharacter;

--- a/src/UtilityFunctions/move/MoveGhost.ts
+++ b/src/UtilityFunctions/move/MoveGhost.ts
@@ -1,118 +1,275 @@
 import GhostCharacter from "../../Types/Character/GhostCharacter";
-import Ghost from "../../Components/GameFieldComponent/GhostComponents/Ghost3";
+import Ghost1 from "../../Components/GameFieldComponent/GhostComponents/Ghost1";
+import Ghost2 from "../../Components/GameFieldComponent/GhostComponents/Ghost2";
+import Ghost3 from "../../Components/GameFieldComponent/GhostComponents/Ghost3";
+import Ghost4 from "../../Components/GameFieldComponent/GhostComponents/Ghost4";
 import Moveable from "../../Types/Moveable";
 import Direction from "../../Types/Direction";
 import { WritableDraft } from "@reduxjs/toolkit/node_modules/immer/dist/internal";
 
-function ghostMovesRight(gameField: React.FC<any>[][],ghost: WritableDraft<GhostCharacter>): React.FC<any>[][] {
-    gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
-    ghost.cachedField = gameField[ghost.getPosition.y][ghost.getPosition.x + 1];
-    gameField[ghost.getPosition.y][ghost.getPosition.x + 1] = Ghost;
-    ghost.setPositionX = ghost.getPosition.x + 1;
-    return gameField;
+function ghostMovesRight(
+  gameField: React.FC<any>[][],
+  ghost: WritableDraft<GhostCharacter>
+): React.FC<any>[][] {
+  gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
+  ghost.cachedField = gameField[ghost.getPosition.y][ghost.getPosition.x + 1];
+  switch (ghost.name) {
+    case "Ghost1":
+      gameField[ghost.getPosition.y][ghost.getPosition.x + 1] = Ghost1;
+      break;
+    case "Ghost2":
+      gameField[ghost.getPosition.y][ghost.getPosition.x + 1] = Ghost2;
+      break;
+    case "Ghost3":
+      gameField[ghost.getPosition.y][ghost.getPosition.x + 1] = Ghost3;
+      break;
+    case "Ghost4":
+      gameField[ghost.getPosition.y][ghost.getPosition.x + 1] = Ghost4;
+      break;
+    default:
+      break;
+  }
+  ghost.setPositionX = ghost.getPosition.x + 1;
+  return gameField;
 }
 
-function ghostMovesDown(gameField: React.FC<any>[][],ghost: WritableDraft<GhostCharacter>): React.FC<any>[][] {
-    gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
-    ghost.cachedField = gameField[ghost.getPosition.y + 1][ghost.getPosition.x];
-    gameField[ghost.getPosition.y + 1][ghost.getPosition.x] = Ghost;
-    ghost.positionY = ghost.getPosition.y + 1;
-    return gameField;
+function ghostMovesDown(
+  gameField: React.FC<any>[][],
+  ghost: WritableDraft<GhostCharacter>
+): React.FC<any>[][] {
+  gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
+  ghost.cachedField = gameField[ghost.getPosition.y + 1][ghost.getPosition.x];
+  switch (ghost.name) {
+    case "Ghost1":
+      gameField[ghost.getPosition.y + 1][ghost.getPosition.x] = Ghost1;
+      break;
+    case "Ghost2":
+      gameField[ghost.getPosition.y + 1][ghost.getPosition.x] = Ghost2;
+      break;
+    case "Ghost3":
+      gameField[ghost.getPosition.y + 1][ghost.getPosition.x] = Ghost3;
+      break;
+    case "Ghost4":
+      gameField[ghost.getPosition.y + 1][ghost.getPosition.x] = Ghost4;
+      break;
+    default:
+      break;
+  }
+  ghost.positionY = ghost.getPosition.y + 1;
+  return gameField;
 }
 
-function ghostMovesLeft(gameField: React.FC<any>[][],ghost: WritableDraft<GhostCharacter>): React.FC<any>[][] {
-    gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
-    ghost.cachedField = gameField[ghost.getPosition.y][ghost.getPosition.x - 1];
-    gameField[ghost.getPosition.y][ghost.getPosition.x - 1] = Ghost;
-    ghost.setPositionX = ghost.getPosition.x - 1;
-    return gameField;
+function ghostMovesLeft(
+  gameField: React.FC<any>[][],
+  ghost: WritableDraft<GhostCharacter>
+): React.FC<any>[][] {
+  gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
+  ghost.cachedField = gameField[ghost.getPosition.y][ghost.getPosition.x - 1];
+  switch (ghost.name) {
+    case "Ghost1":
+      gameField[ghost.getPosition.y][ghost.getPosition.x - 1] = Ghost1;
+      break;
+    case "Ghost2":
+      gameField[ghost.getPosition.y][ghost.getPosition.x - 1] = Ghost2;
+      break;
+    case "Ghost3":
+      gameField[ghost.getPosition.y][ghost.getPosition.x - 1] = Ghost3;
+      break;
+    case "Ghost4":
+      gameField[ghost.getPosition.y][ghost.getPosition.x - 1] = Ghost4;
+      break;
+    default:
+      break;
+  }
+  ghost.setPositionX = ghost.getPosition.x - 1;
+  return gameField;
 }
 
-function ghostMovesUp(gameField: React.FC<any>[][],ghost: WritableDraft<GhostCharacter>): React.FC<any>[][] {
-    gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
-    ghost.cachedField = gameField[ghost.getPosition.y - 1][ghost.getPosition.x];
-    gameField[ghost.getPosition.y - 1][ghost.getPosition.x] = Ghost;
-
-    ghost.positionY = ghost.getPosition.y-1
-    return gameField;
+function ghostMovesUp(
+  gameField: React.FC<any>[][],
+  ghost: WritableDraft<GhostCharacter>
+): React.FC<any>[][] {
+  gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
+  ghost.cachedField = gameField[ghost.getPosition.y - 1][ghost.getPosition.x];
+  switch (ghost.name) {
+    case "Ghost1":
+      gameField[ghost.getPosition.y - 1][ghost.getPosition.x] = Ghost1;
+      break;
+    case "Ghost2":
+      gameField[ghost.getPosition.y - 1][ghost.getPosition.x] = Ghost2;
+      break;
+    case "Ghost3":
+      gameField[ghost.getPosition.y - 1][ghost.getPosition.x] = Ghost3;
+      break;
+    case "Ghost4":
+      gameField[ghost.getPosition.y - 1][ghost.getPosition.x] = Ghost4;
+      break;
+    default:
+      break;
+  }
+  ghost.positionY = ghost.getPosition.y - 1;
+  return gameField;
 }
 
-function ghostMovesRightTroughPortal(gameField: React.FC<any>[][],ghost: WritableDraft<GhostCharacter>): React.FC<any>[][] {
-    ghost.cachedField = gameField[ghost.getPosition.y][0];
-    gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
-    gameField[ghost.getPosition.y][0] = Ghost;
-    ghost.setPositionX = 0;
-    return gameField;
+function ghostMovesRightTroughPortal(
+  gameField: React.FC<any>[][],
+  ghost: WritableDraft<GhostCharacter>
+): React.FC<any>[][] {
+  ghost.cachedField = gameField[ghost.getPosition.y][0];
+  gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
+  switch (ghost.name) {
+    case "Ghost1":
+      gameField[ghost.getPosition.y][0] = Ghost1;
+      break;
+    case "Ghost2":
+      gameField[ghost.getPosition.y][0] = Ghost2;
+      break;
+    case "Ghost3":
+      gameField[ghost.getPosition.y][0] = Ghost3;
+      break;
+    case "Ghost4":
+      gameField[ghost.getPosition.y][0] = Ghost4;
+      break;
+    default:
+      break;
+  }
+  ghost.setPositionX = 0;
+  return gameField;
 }
 
-function ghostMovesDownTroughPortal(gameField: React.FC<any>[][],ghost: WritableDraft<GhostCharacter>): React.FC<any>[][] {
-    gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
-    ghost.cachedField = gameField[0][ghost.getPosition.x];
-    gameField[0][ghost.getPosition.x] = Ghost;
-    ghost.positionY = 0;
-    return gameField;
+function ghostMovesDownTroughPortal(
+  gameField: React.FC<any>[][],
+  ghost: WritableDraft<GhostCharacter>
+): React.FC<any>[][] {
+  gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
+  ghost.cachedField = gameField[0][ghost.getPosition.x];
+  switch (ghost.name) {
+    case "Ghost1":
+      gameField[0][ghost.getPosition.x] = Ghost1;
+      break;
+    case "Ghost2":
+      gameField[0][ghost.getPosition.x] = Ghost2;
+      break;
+    case "Ghost3":
+      gameField[0][ghost.getPosition.x] = Ghost3;
+      break;
+    case "Ghost4":
+      gameField[0][ghost.getPosition.x] = Ghost4;
+      break;
+    default:
+      break;
+  }
+  ghost.positionY = 0;
+  return gameField;
 }
 
-function ghostMovesLeftTroughPortal(gameField: React.FC<any>[][],ghost: WritableDraft<GhostCharacter>): React.FC<any>[][] {
-    gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
-    ghost.cachedField = gameField[ghost.getPosition.y][gameField[0].length - 1];
-    gameField[ghost.getPosition.y][gameField[0].length - 1] = Ghost;
-    ghost.setPositionX = gameField[0].length - 1;
-    return gameField;
+function ghostMovesLeftTroughPortal(
+  gameField: React.FC<any>[][],
+  ghost: WritableDraft<GhostCharacter>
+): React.FC<any>[][] {
+  gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
+  ghost.cachedField = gameField[ghost.getPosition.y][gameField[0].length - 1];
+  switch (ghost.name) {
+    case "Ghost1":
+      gameField[ghost.getPosition.y][gameField[0].length - 1] = Ghost1;
+      break;
+    case "Ghost2":
+      gameField[ghost.getPosition.y][gameField[0].length - 1] = Ghost2;
+      break;
+    case "Ghost3":
+      gameField[ghost.getPosition.y][gameField[0].length - 1] = Ghost3;
+      break;
+    case "Ghost4":
+      gameField[ghost.getPosition.y][gameField[0].length - 1] = Ghost4;
+      break;
+    default:
+      break;
+  }
+  ghost.setPositionX = gameField[0].length - 1;
+  return gameField;
 }
 
-function ghostMovesUpTroughPortal(gameField: React.FC<any>[][],ghost: WritableDraft<GhostCharacter>): React.FC<any>[][] {
-    gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
-    ghost.cachedField = gameField[gameField.length - 1][ghost.getPosition.x];
-    gameField[gameField.length - 1][ghost.getPosition.x] = Ghost;
-    ghost.positionY = gameField.length - 1;
-    return gameField;
+function ghostMovesUpTroughPortal(
+  gameField: React.FC<any>[][],
+  ghost: WritableDraft<GhostCharacter>
+): React.FC<any>[][] {
+  gameField[ghost.getPosition.y][ghost.getPosition.x] = ghost.cachedField;
+  ghost.cachedField = gameField[gameField.length - 1][ghost.getPosition.x];
+  switch (ghost.name) {
+    case "Ghost1":
+      gameField[gameField.length - 1][ghost.getPosition.x] = Ghost1;
+      break;
+    case "Ghost2":
+      gameField[gameField.length - 1][ghost.getPosition.x] = Ghost2;
+      break;
+    case "Ghost3":
+      gameField[gameField.length - 1][ghost.getPosition.x] = Ghost3;
+      break;
+    case "Ghost4":
+      gameField[gameField.length - 1][ghost.getPosition.x] = Ghost4;
+      break;
+    default:
+      break;
+  }
+  ghost.positionY = gameField.length - 1;
+  return gameField;
 }
 
-function moveGhost(gameField:React.FC<any>[][],ghost:WritableDraft<GhostCharacter>)
-{
+function moveGhost(
+  gameField: React.FC<any>[][],
+  ghost: WritableDraft<GhostCharacter>
+) {
   ghost.incrementCount();
-  if(ghost.moveable === Moveable.Yes){
-    switch(ghost.direction){
-      case Direction.Up:{
-        gameField = ghostMovesUp(gameField,ghost);
+  if (ghost.moveable === Moveable.Yes) {
+    switch (ghost.direction) {
+      case Direction.Up: {
+        gameField = ghostMovesUp(gameField, ghost);
         break;
       }
-      case Direction.Down:{
-        gameField = ghostMovesDown(gameField,ghost);
+      case Direction.Down: {
+        gameField = ghostMovesDown(gameField, ghost);
         break;
       }
-      case Direction.Left:{
-        gameField = ghostMovesLeft(gameField,ghost);
+      case Direction.Left: {
+        gameField = ghostMovesLeft(gameField, ghost);
         break;
       }
-      case Direction.Right:{
-        gameField = ghostMovesRight(gameField,ghost);
+      case Direction.Right: {
+        gameField = ghostMovesRight(gameField, ghost);
+        break;
+      }
+    }
+  } else if (ghost.moveable === Moveable.Portal) {
+    switch (ghost.direction) {
+      case Direction.Up: {
+        gameField = ghostMovesUpTroughPortal(gameField, ghost);
+        break;
+      }
+      case Direction.Down: {
+        gameField = ghostMovesDownTroughPortal(gameField, ghost);
+        break;
+      }
+      case Direction.Left: {
+        gameField = ghostMovesLeftTroughPortal(gameField, ghost);
+        break;
+      }
+      case Direction.Right: {
+        gameField = ghostMovesRightTroughPortal(gameField, ghost);
         break;
       }
     }
   }
-  else if(ghost.moveable === Moveable.Portal){
-    switch(ghost.direction){
-      case Direction.Up:{
-        gameField = ghostMovesUpTroughPortal(gameField,ghost);
-        break;
-      }
-      case Direction.Down:{
-        gameField = ghostMovesDownTroughPortal(gameField,ghost);
-        break;
-      }
-      case Direction.Left:{
-        gameField = ghostMovesLeftTroughPortal(gameField,ghost);
-        break;
-      }
-      case Direction.Right:{
-        gameField = ghostMovesRightTroughPortal(gameField,ghost);
-        break;
-      }
-    }
-  }
-    return gameField;
+  return gameField;
 }
 
-export {ghostMovesDown,ghostMovesDownTroughPortal,ghostMovesLeft,ghostMovesLeftTroughPortal,ghostMovesRight,ghostMovesRightTroughPortal,ghostMovesUp,ghostMovesUpTroughPortal,moveGhost};
+export {
+  ghostMovesDown,
+  ghostMovesDownTroughPortal,
+  ghostMovesLeft,
+  ghostMovesLeftTroughPortal,
+  ghostMovesRight,
+  ghostMovesRightTroughPortal,
+  ghostMovesUp,
+  ghostMovesUpTroughPortal,
+  moveGhost,
+};


### PR DESCRIPTION
Vorher:
- Geister waren nicht essbar

Nachher:
- Geister können gegessen werden, sofern ihre Farbe hellblau ist
- nach dem Essen, wird der jeweilige Geist auf seine Startposition zurückgesetzt und ist nicht mehr essbar

Testen:
- große Münze essen, Geister jagen (Essbarkeit ist nur für 15 Sekunden aktiv!!)