### PR TITLE
Timer stoppen für den Schutzblock bei Pausierung

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,13 +44,18 @@ const App: React.FC = () => {
 
   useEffect(() => {
     let [blockTimerStart, blockTimerStop] = CustomTimeOut(() => store.dispatch(deleteBlock), 5000);
-    if (!canSetBlock) {
-      blockTimerStart()
+    if(!isPaused){
+      if (!canSetBlock) {
+        blockTimerStart()
+      }
+    }
+    else if(isPaused){
+      blockTimerStop()
     }
     return () => {
       blockTimerStop();
     }
-  }, [canSetBlock])
+  }, [canSetBlock, isPaused])
 
   useEffect(() => {
     let [canJumpTimerStart, canJumpTimerStop] = CustomTimeOut(() => store.dispatch(enableJumpingFeature), 5000);

--- a/src/State/slices/gameFieldSlice.ts
+++ b/src/State/slices/gameFieldSlice.ts
@@ -342,7 +342,7 @@ const gameFieldSlice = createSlice({
       }
     },
     pauseGame: (state, payload: PayloadAction<boolean>) => {
-      state.isPaused = payload.payload;
+      state.isPaused = payload.payload;      
     },
     openOptions: (state, payload:PayloadAction<boolean>) => {
       state.options = payload.payload


### PR DESCRIPTION
Vorher:
- Timer für Schutzblock wurde nicht gestoppt
- Schutzblock verschwindet trotz Pausierung


Nachher:
- Timer wird gestoppt
- Schutzwall bleibt vorhanden und verschwindet erst nach Fortsetzen des Spiel

Testbarkeit:
- Spielen, Block setzen und per ESC- oder P-Taste Spiel pausieren, ein paar Sekunden warten, Spiel fortsetzen